### PR TITLE
Catch "Permission denied" error

### DIFF
--- a/serverauditor_sshconfig/sa_import.py
+++ b/serverauditor_sshconfig/sa_import.py
@@ -174,14 +174,22 @@ Host {host}
                 key_name = os.path.expanduser(get_key_path(key))
 
                 if key['private_key']:
-                    with open(key_name, 'w') as private_file:
-                        private_file.write(key['private_key'])
-                    os.chmod(key_name, stat.S_IWUSR | stat.S_IRUSR)
+                    try:
+                        with open(key_name, 'w') as private_file:
+                            private_file.write(key['private_key'])
+                        os.chmod(key_name, stat.S_IWUSR | stat.S_IRUSR)
+                    except Exception as e:
+                        print('Error writing to file %s' % key['label'])
+                        print(str(e))
 
                 if key['public_key']:
-                    with open(key_name + '.pub', 'w') as public_file:
-                        public_file.write(key['public_key'])
-                    os.chmod(key_name + '.pub', stat.S_IWUSR | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+                    try:
+                        with open(key_name + '.pub', 'w') as public_file:
+                            public_file.write(key['public_key'])
+                        os.chmod(key_name + '.pub', stat.S_IWUSR | stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+                    except Exception as e:
+                        print('Error writing to file %s' % key['label'])
+                        print(str(e))
 
             return
 


### PR DESCRIPTION
A quick hack to solve the import error at my side. Just an FYI PR in case someone else need it.

The erroneous key: `{'label': '/', 'private_key': 'U', 'public_key': ''}`

Error:

```
Error! [Errno 13] Permission denied: '/-1'
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/serverauditor_sshconfig/core/application.py", line 32, in wrapped
    func(self)
  File "/usr/local/lib/python3.4/site-packages/serverauditor_sshconfig/sa_import.py", line 189, in _create_keys_and_connections
    create_connection(conn)
  File "/usr/local/lib/python3.4/site-packages/serverauditor_sshconfig/sa_import.py", line 177, in create_connection
    with open(key_name, 'w') as private_file:
PermissionError: [Errno 13] Permission denied: '/-1'
```

