### PR TITLE
Fix listing hosts

### DIFF
--- a/termius/core/storage/__init__.py
+++ b/termius/core/storage/__init__.py
@@ -157,7 +157,7 @@ class ApplicationStorage(object):
         return self.model_constructor(single_model, model_class)
 
     def filter(self, model_class, query_union=None, **kwargs):
-        """Filter model list with passed lookups.
+        """Filter the model list with passed lookups.
 
         Usage:
             list = storage.filter(Model, any, **{'field.ge': 1, 'field.le': 5}
@@ -167,6 +167,19 @@ class ApplicationStorage(object):
         query = Query(query_union, **kwargs)
         models = self.get_all(model_class)
         founded_models = [i for i in models if query(i)]
+        return founded_models
+
+    def exclude(self, model_class, query_union=None, **kwargs):
+        """Exclude the model list when matches the lookups.
+
+        Usage:
+            list = storage.exclude(Model, any, **{'field.ge': 1, 'field.le': 5}
+        """
+        assert isinstance(model_class, type)
+        assert kwargs
+        query = Query(query_union, **kwargs)
+        models = self.get_all(model_class)
+        founded_models = [i for i in models if not query(i)]
         return founded_models
 
     def get_all(self, model_class):

--- a/termius/handlers/host.py
+++ b/termius/handlers/host.py
@@ -110,7 +110,7 @@ class HostsCommand(SshConfigPrepareMixin, ListCommand):
 
     def get_hosts(self, group_id):
         """Get host list by group id."""
-        return self.storage.filter(Host, **{'group': group_id})
+        return self.storage.filter(Host, **{'group.id': group_id})
 
     def get_group_id(self, args):
         """Get group id by group id or label."""

--- a/termius/handlers/host.py
+++ b/termius/handlers/host.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 from cached_property import cached_property
 from ..core.commands import DetailCommand, ListCommand
 from ..core.commands.single import RequiredOptions
-from ..core.commands.mixins import SshConfigPrepareMixin
+from ..core.commands.mixins import SshConfigPrepareMixin, GroupStackGetterMixin
 from ..core.storage.strategies import RelatedGetStrategy
 from ..core.models.terminal import Host, Group, TagHost
 from .taghost import TagListArgs
@@ -75,7 +75,7 @@ class HostCommand(DetailCommand):
         return instance
 
 
-class HostsCommand(SshConfigPrepareMixin, ListCommand):
+class HostsCommand(SshConfigPrepareMixin, GroupStackGetterMixin, ListCommand):
     """Manage host objects."""
 
     model_class = Host
@@ -102,22 +102,26 @@ class HostsCommand(SshConfigPrepareMixin, ListCommand):
     # pylint: disable=unused-argument
     def take_action(self, parsed_args):
         """Process CLI call."""
-        group_id = self.get_group_id(parsed_args)
-        hosts = self.get_hosts(group_id)
+        group = self.get_group(parsed_args)
+        hosts = self.get_hosts(group)
         if parsed_args.tags:
             hosts = self.filter_host_by_tags(hosts, parsed_args.tags)
         return self.prepare_result(hosts)
 
-    def get_hosts(self, group_id):
+    def get_hosts(self, parent_group):
         """Get host list by group id."""
-        if group_id:
-            return self.storage.filter(Host, **{'group.id': group_id})
-        else:
-            return self.storage.filter(Host, **{'group': None})
+        if not parent_group:
+            return self.storage.get_all(Host)
+        group_stack = self.get_group_stack(parent_group)
+        group_id_stack = [i.id for i in group_stack]
+        filter_operation = {'group': None}
+        if len(group_id_stack) > 0:
+            filter_operation['group.id.rcontains'] = group_id_stack
+        return self.storage.exclude(Host, any, **filter_operation)
 
-    def get_group_id(self, args):
+    def get_group(self, args):
         """Get group id by group id or label."""
-        return args.group and self.get_relation(Group, args.group).id
+        return args.group and self.get_relation(Group, args.group)
 
     def filter_host_by_tags(self, hosts, tags):
         """Filter host list by tag csv list."""

--- a/termius/handlers/host.py
+++ b/termius/handlers/host.py
@@ -110,7 +110,10 @@ class HostsCommand(SshConfigPrepareMixin, ListCommand):
 
     def get_hosts(self, group_id):
         """Get host list by group id."""
-        return self.storage.filter(Host, **{'group.id': group_id})
+        if group_id:
+            return self.storage.filter(Host, **{'group.id': group_id})
+        else:
+            return self.storage.filter(Host, **{'group': None})
 
     def get_group_id(self, args):
         """Get group id by group id or label."""
@@ -122,10 +125,10 @@ class HostsCommand(SshConfigPrepareMixin, ListCommand):
         tag_ids = [i.id for i in tags]
         host_ids = [i.id for i in hosts]
         taghost_instances = self.storage.filter(TagHost, all, **{
-            'tag.rcontains': tag_ids
+            'tag.id.rcontains': tag_ids
         })
-        filtered_host_id = {i.host for i in taghost_instances}
-        intersected_host_ids = set(host_ids) and filtered_host_id
+        filtered_host_ids = {i.host.id for i in taghost_instances}
+        intersected_host_ids = set(host_ids) & filtered_host_ids
         return self.storage.filter(
             Host, **{'id.rcontains': intersected_host_ids}
         )

--- a/tests/integration/groups.bats
+++ b/tests/integration/groups.bats
@@ -25,8 +25,8 @@ setup() {
 
 @test "List groups in subgroup in table format" {
     parent=$(termius group -L 'test group' --port 2 --username 'use r name')
-    termius group -L 'test group' --parent-group $parent --port 2 --username 'use r name'
-    run termius groups $parent
+    child=$(termius group -L 'test group' --parent-group $parent --port 2 --username 'use r name')
+    run termius groups -f csv -c id $parent
     [ "$status" -eq 0 ]
     [ $(get_models_set_length 'group_set') -eq 2 ]
 }

--- a/tests/integration/hosts.bats
+++ b/tests/integration/hosts.bats
@@ -28,15 +28,18 @@ setup() {
 
     run termius hosts --tag A
     [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "$host" ]
+    [ "${lines[2]}" = "" ]
     [ $(get_models_set_length 'host_set') -eq 2 ]
 }
 
 @test "List hosts in group" {
     group=$(termius group --port 2022)
-    termius host -L test --group $group --address localhost --username root --password password
+    host_id=$(termius host -L test --group $group --address localhost --username root --password password)
 
-    run termius hosts --group $group
+    run termius hosts --group $group -f csv -c id
     [ "$status" -eq 0 ]
+
     [ $(get_models_set_length 'host_set') -eq 1 ]
 }
 

--- a/tests/integration/hosts.bats
+++ b/tests/integration/hosts.bats
@@ -33,8 +33,9 @@ setup() {
     [ $(get_models_set_length 'host_set') -eq 2 ]
 }
 
-@test "List hosts in group" {
+@test "List hosts in a group" {
     group=$(termius group --port 2022)
+    termius host -L test --address localhost --username root --password password
     host_id=$(termius host -L test --group $group --address localhost --username root --password password)
 
     run termius hosts --group $group -f csv -c id
@@ -42,10 +43,51 @@ setup() {
 
     [ "${lines[1]}" = "$host_id" ]
     [ "${lines[2]}" = "" ]
+    [ $(get_models_set_length 'host_set') -eq 2 ]
+}
+
+@test "List hosts in the root group" {
+    group=$(termius group --port 2022)
+    host_id=$(termius host -L test --group $group --address localhost --username root --password password)
+
+    run termius hosts -f csv -c id
+    [ "$status" -eq 0 ]
+
+    [ "${lines[1]}" = "$host_id" ]
+    [ "${lines[2]}" = "" ]
     [ $(get_models_set_length 'host_set') -eq 1 ]
 }
 
-@test "List hosts in group filter by tag" {
+@test "List hosts in child groups, too" {
+    group=$(termius group --port 2022)
+    child_group=$(termius group --parent-group $group --port 2022)
+    termius host -L test --address localhost --username root --password password
+    host_id=$(termius host -L test --group $child_group --address localhost --username root --password password)
+
+    run termius hosts --group $group -f csv -c id
+    [ "$status" -eq 0 ]
+
+    [ "${lines[1]}" = "$host_id" ]
+    [ "${lines[2]}" = "" ]
+    [ $(get_models_set_length 'host_set') -eq 2 ]
+}
+
+@test "List hosts only in child groups" {
+    group=$(termius group --port 2022)
+    child_group=$(termius group --parent-group $group --port 2022)
+    termius host -L test --address localhost --username root --password password
+    termius host -L test --group $group --address localhost --username root --password password
+    host_id=$(termius host -L test --group $child_group --address localhost --username root --password password)
+
+    run termius hosts --group $child_group -f csv -c id
+    [ "$status" -eq 0 ]
+
+    [ "${lines[1]}" = "$host_id" ]
+    [ "${lines[2]}" = "" ]
+    [ $(get_models_set_length 'host_set') -eq 3 ]
+}
+
+@test "List hosts in a group filter by the tag" {
     group=$(termius group --port 2022)
     host_id=$(termius host -L test --group $group --address localhost --username root --password password -t A)
     termius host -L test --address localhost --username root --password password -t A
@@ -55,4 +97,15 @@ setup() {
     [ "${lines[1]}" = "$host_id" ]
     [ "${lines[2]}" = "" ]
     [ $(get_models_set_length 'host_set') -eq 2 ]
+}
+
+@test "List hosts filter by a tag acrous all gropus" {
+    group=$(termius group --port 2022)
+    host_id=$(termius host -L test --group $group --address localhost --username root --password password -t A)
+
+    run termius hosts --tag A -f csv -c id
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "$host_id" ]
+    [ "${lines[2]}" = "" ]
+    [ $(get_models_set_length 'host_set') -eq 1 ]
 }

--- a/tests/integration/hosts.bats
+++ b/tests/integration/hosts.bats
@@ -24,11 +24,11 @@ setup() {
 
 @test "List hosts filter by tag" {
     termius host -L test --port 2022 --address localhost --username root --password password
-    termius host -L test --port 2022 --address localhost --username root --password password -t A
+    host_id=$(termius host -L test --port 2022 --address localhost --username root --password password -t A)
 
-    run termius hosts --tag A
+    run termius hosts --tag A -f csv -c id
     [ "$status" -eq 0 ]
-    [ "${lines[1]}" = "$host" ]
+    [ "${lines[1]}" = "$host_id" ]
     [ "${lines[2]}" = "" ]
     [ $(get_models_set_length 'host_set') -eq 2 ]
 }
@@ -40,14 +40,19 @@ setup() {
     run termius hosts --group $group -f csv -c id
     [ "$status" -eq 0 ]
 
+    [ "${lines[1]}" = "$host_id" ]
+    [ "${lines[2]}" = "" ]
     [ $(get_models_set_length 'host_set') -eq 1 ]
 }
 
 @test "List hosts in group filter by tag" {
     group=$(termius group --port 2022)
-    termius host -L test --group $group --address localhost --username root --password password -t A
+    host_id=$(termius host -L test --group $group --address localhost --username root --password password -t A)
+    termius host -L test --address localhost --username root --password password -t A
 
-    run termius hosts --tag A --group $group
+    run termius hosts --tag A --group $group -f csv -c id
     [ "$status" -eq 0 ]
-    [ $(get_models_set_length 'host_set') -eq 1 ]
+    [ "${lines[1]}" = "$host_id" ]
+    [ "${lines[2]}" = "" ]
+    [ $(get_models_set_length 'host_set') -eq 2 ]
 }


### PR DESCRIPTION
List all hosts in all child groups inside the group in addition to
listing hosts in the group.

In case of the following group structure:
```
parent group/
├── host 1
├── host 2
└── child group/
    ├── child host 1
    └── child host 2
```

The next commands lists: `host 1`, `host 2`, `child host 1`, `child
host 2`.

```bash
$ termius hosts -c label
$ termius hosts --group 'parent group' -c label
```

In other case, the next command lists: `child host 1 and `child host 2`:

```bash
$ termius hosts -c label --group 'child group'
```