### PR TITLE
Fix listing groups

### DIFF
--- a/termius/handlers/group.py
+++ b/termius/handlers/group.py
@@ -92,9 +92,11 @@ class GroupsCommand(SshConfigPrepareMixin, ListCommand):
 
     def get_groups(self, group_id):
         """Retrieve all child groups of passed group."""
-        return self.storage.filter(
-            Group, **{'parent_group': group_id}
-        )
+        if group_id:
+            filter_operation = {'parent_group.id': group_id}
+        else:
+            filter_operation = {'parent_group': None}
+        return self.storage.filter(Group, **filter_operation)
 
     def get_parent_group_id(self, args):
         """Return parent group id  or None from command line arguments."""

--- a/tests/integration/groups.bats
+++ b/tests/integration/groups.bats
@@ -23,19 +23,42 @@ setup() {
     [ $(get_models_set_length 'group_set') -eq 1 ]
 }
 
-@test "List groups in subgroup in table format" {
+@test "List subgroups in a group in table format" {
+    parent=$(termius group -L 'test group' --port 2 --username 'use r name')
+    child=$(termius group -L 'test group' --parent-group $parent --port 2 --username 'use r name')
+    run termius groups $parent
+    [ "$status" -eq 0 ]
+    [ $(get_models_set_length 'group_set') -eq 2 ]
+}
+
+@test "List subgroups in a group" {
     parent=$(termius group -L 'test group' --port 2 --username 'use r name')
     child=$(termius group -L 'test group' --parent-group $parent --port 2 --username 'use r name')
     run termius groups -f csv -c id $parent
     [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "$child" ]
+    [ "${lines[2]}" = "" ]
     [ $(get_models_set_length 'group_set') -eq 2 ]
+}
+
+@test "List subgroups in the root group" {
+    parent=$(termius group -L 'test group' --port 2 --username 'use r name')
+    termius group -L 'test group' --parent-group $parent --port 2 --username 'use r name'
+    termius group -L 'test group' --parent-group $parent --port 2 --username 'use r name'
+    run termius groups -f csv -c id
+    [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "$parent" ]
+    [ "${lines[2]}" = "" ]
+    [ $(get_models_set_length 'group_set') -eq 3 ]
 }
 
 @test "List groups recursivly in subgroup in table format" {
     grandparent=$(termius group -L 'test group' --port 2 --username 'use r name')
     parent=$(termius group -L 'test group' --parent-group $grandparent --port 2 --username 'use r name')
     termius group -L 'test group' --parent-group $parent --port 2 --username 'use r name'
-    run termius groups $grandparent
+    run termius groups -f csv -c id $grandparent
     [ "$status" -eq 0 ]
+    [ "${lines[1]}" = "$parent" ]
+    [ "${lines[2]}" = "" ]
     [ $(get_models_set_length 'group_set') -eq 3 ]
 }


### PR DESCRIPTION
In case of the following group structure:
```
parent group/
└── child group/
```

The next commands lists: `child group`.

```bash
$ termius groups --group 'parent group' -c label
```

In other case, the next command lists: `parent group`.

```bash
$ termius groups -c label
```

To list all groups I use `--recursive` or `-r` option. The next command
lists: `parent group` and `child group`.

```bash
$ termius groups -r
```

Fix #24